### PR TITLE
表記揺れの修正

### DIFF
--- a/3language-basics.re
+++ b/3language-basics.re
@@ -200,7 +200,7 @@ my-special-swap!
 
 #@# There is almost nothing new we can explain about strings that you don't already know. In  ClojureScript , they work the same as in any other language. One point of interest, however, is that they are immutable.
 #@# In this case they are the same as in  JavaScript :
-文字列については特に説明することはありません。ClojureScript は、他の言語と同じように動作します。ただし、文字列が不可変である点に注意してください。
+文字列については特に説明することはありません。ClojureScript は、他の言語と同じように動作します。ただし、文字列が不変である点に注意してください。
 この点は JavaScript と同じです。
 
 //emlist{
@@ -248,7 +248,7 @@ ClojureScript の文字列で特異な点は、Lisp の構文に由来するも�
 #@# ClojureScript comes with many types of collections. The main difference between ClojureScript collections and collections in other languages is that they are persistent and immutable.
 #@# Before moving on to these (possibly) unknown concepts, we'll present a high-level overview of existing collection types in  ClojureScript .
 あるプログラミング言語について詳しく知るためには、その言語でコレクションがどのように抽象化されているかを知る必要があります。ClojureScript にも当てはまります。
-ClojureScript のコレクションには多くの型があります。ClojureScript が他の言語のコレクションと違うのは、コレクションが永続的で不可変であることです。
+ClojureScript のコレクションには多くの型があります。ClojureScript が他の言語のコレクションと違うのは、コレクションが永続的で不変であることです。
 詳しい説明に入る前に ClojureScript のコレクションに存在する型について概要を見ましょう。
 
 ===== リスト
@@ -409,7 +409,7 @@ ClojureScript のコレクションには多くの型があります。ClojureSc
 #@#  vars
 
 #@# ClojureScript is a mostly functional language that focuses on immutability. Because of that, it does not have the concept of  var iables as you know them in most other programming languages. The closest analogy to  variables are the  variables you define in algebra; when you say `x == 6` in mathematics, you are saying that you want the symbol x to stand for the number six.
-ClojureScript は関数型プログラミング言語であり、不可変性に重点をおいています。そのため、他の言語の変数にあたる概念がありません。代数学における変数にあたる概念はあります。つまり数学で x == 6 というときには、x というシンボルが 6 を表すということを意味します。
+ClojureScript は関数型プログラミング言語であり、不変性に重点をおいています。そのため、他の言語の変数にあたる概念がありません。代数学における変数にあたる概念はあります。つまり数学で x == 6 というときには、x というシンボルが 6 を表すということを意味します。
 
 #@# In  ClojureScript ,  var s are represented by symbols and store a single value together with metadata.
 #@# You can define a var using the def special form:
@@ -831,7 +831,7 @@ callable プロトコル(IFn については後述)を実装する能力と一�
 ClojureScript には ALGOL のような変数の概念がありませんが、ローカル(local)はあります。ローカルはイミュータブルであり、変更しようとするとエラーが発生します。
 
 #@# Locals are defined with the let expression. The expression starts with a vector as the first parameter followed by an arbitrary number of expressions. The first parameter (the vector) should contain an arbitrary number of pairs that give a _binding form_ (usually a symbol) followed by an expression whose value will be bound to this new local for the remainder of the let expression.
-ローカルは let 式で定義されます。let 式は、最初のパラメータとしてベクトルで始まり、その後に任意の数の式が続きます。最初のパラメータのベクトルには束縛フォームを与えて、その let 内のローカルで有効な名前と値のペアを宣言します。
+ローカルは let 式で定義されます。let 式は、最初のパラメータとしてベクタで始まり、その後に任意の数の式が続きます。最初のパラメータのベクタには束縛フォームを与えて、その let 内のローカルで有効な名前と値のペアを宣言します。
 
 //emlist{
 (let [x (inc 1)
@@ -1083,7 +1083,7 @@ map 関数の初めのパラメータには、1 つの引数をとり 1 つの�
 上の例では、短い構文を使っていません。なぜなら、短い構文を使うとタイピング数を減らせますが、コードの可読性が低下する可能性があるからです。新しい言語を始めるときは、自分が書いたものを後で読めることは重要です。もし短い構文に慣れている場合は、この構文を使用してください。
 
 #@# Remember to choose your starting value for the accumulator carefully. If you wanted to use reduce to find the product of a series of numbers, you would have to start with one rather than zero, otherwise all the numbers would be multiplied by zero!
-アキュミュレータに渡す開始値は慎重に選ぶ必要があることを覚えておいてください。一連の数の積を求めるために reduce を使うときは、0ではなく 1 を開始値として使う必要があります。0 を用いて掛け算をすることができないためです。
+アキュムレータに渡す開始値は慎重に選ぶ必要があることを覚えておいてください。一連の数の積を求めるために reduce を使うときは、0ではなく 1 を開始値として使う必要があります。0 を用いて掛け算をすることができないためです。
 
 //emlist{
 ;; wrong starting value
@@ -1108,7 +1108,7 @@ for は束縛のためのベクタと式をとり、式が評価された結果�
 //}
 
 #@# In this example, x is bound to each of the items in the vector `[1 2 3]` in turn, and returns a new sequence of two-item vectors with the original item squared.
-この例では、x は [1 2 3] の各要素に順に束縛され、元の要素と それを 2 乗した値をもつ 2 要素ベクトルの新しいシーケンスを返します。
+この例では、x は [1 2 3] の各要素に順に束縛され、元の要素と それを 2 乗した値をもつ 2 要素ベクタの新しいシーケンスを返します。
 
 #@# for supports multiple bindings, which will cause the collections to be iterated in a nested fashion, much like nesting for loops in imperative languages. The innermost binding iterates “fastest.”
 複数の束縛をサポートしているため、命令型言語での for ループのネストと同様に、コレクションがネストされて反復されます。最も内側の束縛が「最も速く」繰り返されます。
@@ -1182,7 +1182,7 @@ for は束縛のためのベクタと式をとり、式が評価された結果�
 //}
 
 #@# When we outlined the most common usages of the for construct in imperative programming languages, we mentioned that sometimes we want to run a computation for every value in a sequence, not caring about the result. Presumably we do this for achieving some sort of side-effect with the values of the sequence.
-先ほど、命令型プログラミング言語での for の用法として、結果を気にせずにシーケンス内のすべての値に対して計算を実行したい場合があることを述べました。おそらく、シークエンスの各値で何らかの副作用を達成するためにこれを行います。
+先ほど、命令型プログラミング言語での for の用法として、結果を気にせずにシーケンス内のすべての値に対して計算を実行したい場合があることを述べました。おそらく、シーケンスの各値で何らかの副作用を達成するためにこれを行います。
 
 
 #@# Page29
@@ -1435,7 +1435,7 @@ ClojureScript コレクションを変換するための中心的な関数は、
 //} 
  
 #@# NOTE: When you use the map function on a map collection, your higher-order function will receive a two-item vector containing a key and value from the map. The following example uses xref:destructuring-section[destructuring] to access the key and value.
-map 関数をマップのコレクションに対して使うとき、高階関数はキーと値を含む 2 つのアイテムからなるベクトルを受け取ります。次の例では、キーと値にアクセスするために destructuring を使います。
+map 関数をマップのコレクションに対して使うとき、高階関数はキーと値を含む 2 つのアイテムからなるベクタを受け取ります。次の例では、キーと値にアクセスするために destructuring を使います。
 
 //embed[latex]{
 \vspace{-0.2\Cvs}
@@ -1689,7 +1689,7 @@ range だけで呼び出した場合、整数の無限シーケンスを生成�
 #@# Lists
 
 #@# In  ClojureScript , lists are mostly used as a data structure for grouping symbols together into programs. Unlike in other  Lisp s, many of the syntactic constructs of ClojureScript use data structures different from the list (vectors and maps).  This makes code less uniform, but the gains in readability are well worth the price.
-ClojureScriptでは、シンボルをグループ化してプログラムにするためのデータ構造として、主にリストが使用されます。他の Lisp 方言とは異なり、ClojureScript ではリストとは異なるデータ構造体を使用します(ベクトルとマップ)。このことによりコードの統一感が低下しますが、コードの読みやすさは向上します。
+ClojureScriptでは、シンボルをグループ化してプログラムにするためのデータ構造として、主にリストが使用されます。他の Lisp 方言とは異なり、ClojureScript ではリストとは異なるデータ構造体を使用します(ベクタとマップ)。このことによりコードの統一感が低下しますが、コードの読みやすさは向上します。
 
 #@# You can think of ClojureScript lists as singly linked lists, where each node contains a value and a pointer to the rest of the list. This makes it natural (and fast!) to add items to the front of the list, since adding to the end would require traversal of the entire list. The prepend operation is performed using the cons function.
 ClojureScript のリストは、各ノードに値とリストの残りの部分へのポインタが含まれる連結リストだと考えることができます。リストの最後に項目を追加するにはリスト全体を横断する必要がありますが、リストの先頭に項目を追加するのは自然に(高速に)できます。リストの最初に要素を追加するには、cons 関数を用います。
@@ -1797,7 +1797,7 @@ ClojureScript のベクタは、リテラル表現として角括弧 [] を使�
 //} 
 
 #@# Another thing that differentiates lists and vectors is that vectors are indexed collections and as such support efficient random index access and non-destructive updates. We can use the nth function to retrieve values given an index:
-リストとベクトルを区別するもう 1 つの点は、ベクタはインデックス付きコレクションであり、効率的なランダムアクセスや非破壊更新をサポートする点です。nth 関数を使うと、指定されたインデックスの値を取得できます。
+リストとベクタを区別するもう 1 つの点は、ベクタはインデックス付きコレクションであり、効率的なランダムアクセスや非破壊更新をサポートする点です。nth 関数を使うと、指定されたインデックスの値を取得できます。
 
 //emlist{
 (nth [0 1 2] 0)
@@ -1805,7 +1805,7 @@ ClojureScript のベクタは、リテラル表現として角括弧 [] を使�
 //}
  
 #@# Since vectors associate sequential numeric keys (indexes) to values, we can treat them as an associative data structure. ClojureScript provides the assoc function that, given an associative data structure and a set of key-value pairs, yields a new data structure with the values corresponding to the keys modified. Indexes begin at zero for the first element in a vector.
-ベクトルは連続した数値キー(インデックス)を値に関連付けるので、連想データ構造として扱うことができます。ClojureScript が提供する assoc 関数は、連想データの構造体とキーと値のペアのセットを指定すると、変更されたキーに対応する値を持つ新しいデータの構造体を生成します。インデックスは、ベクトルの最初の要素の 0 から始まります。
+ベクタは連続した数値キー(インデックス)を値に関連付けるので、連想データ構造として扱うことができます。ClojureScript が提供する assoc 関数は、連想データの構造体とキーと値のペアのセットを指定すると、変更されたキーに対応する値を持つ新しいデータの構造体を生成します。インデックスは、ベクタの最初の要素の 0 から始まります。
 
 //emlist{
 (assoc ["cero" "uno" "two"] 2 "dos")
@@ -1813,7 +1813,7 @@ ClojureScript のベクタは、リテラル表現として角括弧 [] を使�
 //}
 
 #@# Note that we can only assoc to a key that is either contained in the vector already or if it is the last position in a vector:
-ベクトルにすでに含まれているキー、またはベクトルの最後の位置にあるキーにのみ assoc を使うことができます。
+ベクタにすでに含まれているキー、またはベクタの最後の位置にあるキーにのみ assoc を使うことができます。
 
 //emlist{
 (assoc ["cero" "uno" "dos"] 3 "tres")
@@ -1872,7 +1872,7 @@ ClojureScript のベクタは、リテラル表現として角括弧 [] を使�
 @<embed>{|latex|\vspace{-0.4\Cvs\}}
 
 #@# The map and filter operations return lazy sequences, but as it is common to need a fully realized sequence after performing those operations, vector-returning counterparts of such functions are available as mapv and filterv. They have the advantages of being faster than building a vector from a lazy sequence and making your intent more explicit:
-map と filter の操作は遅延シーケンスを返しますが、これらの操作の後には完全に実現されたシーケンスが必要なことが一般的なため、ベクトルを返す同等のものとして mapv や filterv 等があります。これらの関数には、遅延シーケンスからベクトルを構築するよりも高速であり、意図をより明確にするという利点があります。
+map と filter の操作は遅延シーケンスを返しますが、これらの操作の後には完全に実現されたシーケンスが必要なことが一般的なため、ベクタを返す同等のものとして mapv や filterv 等があります。これらの関数には、遅延シーケンスからベクタを構築するよりも高速であり、意図をより明確にするという利点があります。
 
 @<embed>{|latex|\vspace{-0.4\Cvs\}}
 
@@ -1965,7 +1965,7 @@ ClojureScript のマップは、リテラル表現として、キーと値のペ
 @<embed>{|latex|\vspace{-0.2\Cvs\}} 
  
 #@# Maps are also functions of their keys, returning the values related to the given keys. Unlike vectors, they return nil if we supply a key that is not present in the map:
-マップはキーの関数でもあり、指定されたキーに関連する値を返します。ベクトルとは異なり、マップに存在しないキーを指定すると、nil が返されます。
+マップはキーの関数でもあり、指定されたキーに関連する値を返します。ベクタとは異なり、マップに存在しないキーを指定すると、nil が返されます。
 
 @<embed>{|latex|\vspace{-0.2\Cvs\}}
 
@@ -2222,7 +2222,7 @@ destructuring(分割)という言葉が示すように、destructuring はコレ
 //}
 
 #@# However, the previous code is overly verbose. Destructuring  let s us extract values of indexed sequences more succintly using a vector on the left-hand side of a binding:
-しかし、前のコードは冗長すぎます。destructuring では、束縛の左側のベクトルを使用して、インデックスがついたシーケンスからより簡潔に値を取り出すことができます。
+しかし、前のコードは冗長すぎます。destructuring では、束縛の左側のベクタを使用して、インデックスがついたシーケンスからより簡潔に値を取り出すことができます。
 
 //emlist{
 (let [[fst _ thrd] [0 1 2]]
@@ -2257,7 +2257,7 @@ destructuring は let での束縛に限定されないことに注意してく�
 //}
 
 #@# Positional destructuring with vectors is quite handy for taking indexed values out of sequences, but sometimes we don't want to discard the rest of the elements in the sequence when destructuring.  Similarly to how & is used for accepting  variadic function arguments, the ampersand can be used inside a vector destructuring form for grouping together the rest of a sequence:
-ベクタを用いた位置の destructuring は、シーケンスからインデックス付きの値を取り出すために非常に便利ですが、シーケンス内の残りの要素を破棄したくない場合があります。可変長引数関数の引数を & で受け取る方法と同様に、& をベクトルの destructuring 内で使用して、シーケンスの残りの部分をグループ化することができます。
+ベクタを用いた位置の destructuring は、シーケンスからインデックス付きの値を取り出すために非常に便利ですが、シーケンス内の残りの要素を破棄したくない場合があります。可変長引数関数の引数を & で受け取る方法と同様に、& をベクタの destructuring 内で使用して、シーケンスの残りの部分をグループ化することができます。
 
 //emlist{
 (let [[fst snd & more] (range 1 0)]
@@ -2876,7 +2876,7 @@ myapp
 一部の動的言語では「モンキーパッチ」が可能です。そのような言語では、クラスは開かれていて、いつでもメソッドを定義したり再定義したりできます。このテクニックは非常に悪い慣習であることもよく知られています。
 
 #@# We can not trust languages that allow you to silently overwrite methods that you are using when you import third party libraries; you cannot expect consistent behavior when this happens.
-サードパーティーのライブラリをインポートするときに、使用しているメソッドを暗黙のうちに上書きできる言語は信頼できません。この場合、一貫した動作は期待できません。
+サードパーティのライブラリをインポートするときに、使用しているメソッドを暗黙のうちに上書きできる言語は信頼できません。この場合、一貫した動作は期待できません。
 
 #@# These symptoms are commonly called the "expression problem"; see http://en.wikipedia.org/wiki/Expression_problem for more details
 これらの問題は Expression Problem として知られています。
@@ -3414,9 +3414,9 @@ ClojureScript には、グローバルあるいはローカルに定義された
 #@# Data types
 
 #@# Until now, we have used maps, sets, lists, and vectors to represent our data. And in most cases, this is a really great approach. But sometimes we need to define our own types, and in this book we will call them *data types*.
-ここまでは、マップ、セット、リスト、ベクターをデータを表現するために使ってきました。多くの場合、これは本当に素晴らしいアプローチです。しかし、自分自身でこのような型を定義する必要があるときもあります。この本では、このような型のことを「データ型」と呼びます。
+ここまでは、マップ、セット、リスト、ベクタをデータを表現するために使ってきました。多くの場合、これは本当に素晴らしいアプローチです。しかし、自分自身でこのような型を定義する必要があるときもあります。この本では、このような型のことを「データ型」と呼びます。
 
-これまでは、マップ、セット、リスト、ベクトルを使ってデータを表現してきました。ほとんどの場合、これは本当に素晴らしいアプローチです。しかし、場合によっては、独自に型を定義する必要があります。本書ではそれらをデータ型と呼ぶことにします。
+これまでは、マップ、セット、リスト、ベクタを使ってデータを表現してきました。ほとんどの場合、これは本当に素晴らしいアプローチです。しかし、場合によっては、独自に型を定義する必要があります。本書ではそれらをデータ型と呼ぶことにします。
 
 #@# A data type provides the following:
 データ型は、次の機能を提供します。
@@ -3902,11 +3902,11 @@ ClojureScript には、プレーンな JavaScript のオブジェクトを作成
 //}
 //embed[latex]{
 \clearpage
-//} 
+//}
 
 
 #@# The return value can be passed to some kind of third party library that accepts a plain JavaScript object, but you can observe the real representation of the return value of this function. It is really another form for doing the same thing.
-返り値は、プレーンな JavaScript のオブジェクトを受け入れる何らかのサードパーティーのライブラリーに渡すことができますが、この関数の戻り値の実際の表現を見ることができます。まったく同じことをするための別の形式です。
+返り値は、プレーンな JavaScript のオブジェクトを受け入れる何らかのサードパーティのライブラリに渡すことができますが、この関数の戻り値の実際の表現を見ることができます。まったく同じことをするための別の形式です。
 
 #@# Using the reader macro `#js` consists of prepending it to a ClojureScript map or vector, and the result will be transformed to plain  JavaScript :
 リーダーマクロの #js を使うことも可能です。マップかベクタの先頭に #js をつけることで、結果が JavaScript のオブジェクトに変換されます。

--- a/4compiler.re
+++ b/4compiler.re
@@ -9,15 +9,15 @@
 
 #@# Getting Started with the Compiler
 
-#@# At this point, you are surely very bored with the constant theoretical explanations about the language itself and will want to write and execute some code. The goal of this section is to provide a little practical introduction to the ClojureScript compiler. 
-前章の言語自体の理論的な説明にうんざりしてしまって、何かコードを書いて実行したいと思われているかもしれません。このセクションの目的は、ClojureScript コンパイラーの実用的な紹介を少し行うことです。
+#@# At this point, you are surely very bored with the constant theoretical explanations about the language itself and will want to write and execute some code. The goal of this section is to provide a little practical introduction to the ClojureScript compiler.
+前章の言語自体の理論的な説明にうんざりしてしまって、何かコードを書いて実行したいと思われているかもしれません。このセクションの目的は、ClojureScript コンパイラの実用的な紹介を少し行うことです。
 
 #@# The ClojureScript compiler takes the source code that has been split over numerous directories and namespaces and compiles it down to JavaScript. Today, JavaScript hasa great number of different environments where it can be executed - each with its own peculiarities.
-ClojureScript のコンパイラは、多くのディレクトリーと名前空間で分けられたソースコードを取得して、JavaScript にコンパイルします。今日では JavaScript を実行できる環境は多くあり、それぞれに固有の特性があります。
+ClojureScript のコンパイラは、多くのディレクトリと名前空間で分けられたソースコードを取得して、JavaScript にコンパイルします。今日では JavaScript を実行できる環境は多くあり、それぞれに固有の特性があります。
 
 #@# This chapter intends to explain how to use ClojureScript without any additional tooling. This will help you understand how the compiler works and how you can use it when other tooling is not available (such as link:http://leiningen.org/[leiningen] +link:https://github.com/emezeske/lein-cljsbuild[cljsbuild] orlink:http://boot-clj.com/[boot]).
 この章では、ツールを追加せずに ClojureScript を使う方法を説明します。
-これは、他のツール(leiningen@<fn>{lein} や @<fn>{boot})が利用できない場合において、コンパイラーの動作や利用法を理解するのに役立ちます。
+これは、他のツール(Leiningen@<fn>{lein} や @<fn>{boot})が利用できない場合において、コンパイラの動作や利用法を理解するのに役立ちます。
 
 //footnote[lein][http://leiningen.org]
 //footnote[boot][http://boot-clj.com]
@@ -93,7 +93,7 @@ v6.2.0
 #@# Create the example application
 
 #@# For the first step of our practical example, we will create our application directory structure and populate it with example code.
-実用的な例を作成する最初のステップとして、アプリケーションのためのディレクトリーを作成します。実用例に使うコードをそこに取り込んでいきます。
+実用的な例を作成する最初のステップとして、アプリケーションのためのディレクトリを作成します。実用例に使うコードをそこに取り込んでいきます。
 
 #@# Start by creating the directory tree structure for our “hello world” application:
 まず、"Hello world" アプリケーションのためのディレクトリを作成しましょう。
@@ -144,7 +144,7 @@ myapp
 //}
 
 #@# NOTE: It is very important that the declared namespace in the file exactly matchesthe directory structure. This is the way ClojureScript structures its source code.
-ファイル内で宣言された名前空間が、ディレクトリーの構造と正確に一致することが非常に重要です。これは、ClojureScript がソースコードを構築する方法です。
+ファイル内で宣言された名前空間が、ディレクトリの構造と正確に一致することが非常に重要です。これは、ClojureScript がソースコードを構築する方法です。
 
 
 ===== アプリケーションのコンパイル
@@ -152,7 +152,7 @@ myapp
 #@# Compile the example application
 
 #@# In order to compile that source code, we need a simple build script that tells theClojureScript compiler the source directory and the output file. ClojureScripthas a lot of other options, but at this moment we can ignore that.
-このソース・コードをコンパイルするためには、ClojureScript コンパイラーにソース・ディレクトリーと出力ファイルを伝える単純なビルド・スクリプトが必要です。ClojureScript には他にも多くの選択肢がありますが、現時点では取り上げません。
+このソース・コードをコンパイルするためには、ClojureScript コンパイラにソース・ディレクトリと出力ファイルを伝える単純なビルド・スクリプトが必要です。ClojureScript には他にも多くの選択肢がありますが、現時点では取り上げません。
 
 
 #@# Let’s create the `myapp/build.clj` file with the following content:
@@ -230,7 +230,7 @@ Hello world!
 このセクションでは、前のセクションの "Hello world" の例と同様のアプリケーションを作成し、ブラウザの環境で実行します。このアプリケーションの最小要件は、JavaScript を実行できるブラウザだけです。
 
 #@# The process is almost the same, and the directory structure is the same. The onlythings that changes is the entry point of the application and the build script. So,start re-creating the directory tree from previous example in a different directory.
-プロセスはほぼ同じで、ディレクトリの構造も同じです。変更するのは、アプリケーションのエントリーポイントとビルド・スクリプトだけです。前の例のディレクトリー・ツリーを元に、別のディレクトリーを再生成します。
+プロセスはほぼ同じで、ディレクトリの構造も同じです。変更するのは、アプリケーションのエントリーポイントとビルド・スクリプトだけです。前の例のディレクトリ・ツリーを元に、別のディレクトリを再生成します。
 
 @<embed>{|latex|\vspace{-0.5\Cvs\}}
 
@@ -330,7 +330,7 @@ java -cp ../cljs.jar:src clojure.main build.clj
 //}
 
 #@# This process can take some time, so do not worry; wait a little bit. The JVM bootstrap with the Clojure compiler is slightly slow. In the following sections, we will explain how to start a watch process to avoid constantly starting and stopping this slow process.
-この処理には時間がかかることがありますが、心配せずに少し待ってください。Clojure コンパイラーを使用した JVM のブートストラップは少し遅いです。以降のセクションでは、このような遅いプロセスの起動と停止を頻繁に行わないように、監視プロセスを開始する方法を説明します。
+この処理には時間がかかることがありますが、心配せずに少し待ってください。Clojure コンパイラを使用した JVM のブートストラップは少し遅いです。以降のセクションでは、このような遅いプロセスの起動と停止を頻繁に行わないように、監視プロセスを開始する方法を説明します。
 
 #@# While waiting for the compilation, let's create a dummy HTML file to make it easy toexecute our example app in the browser. Create the _index.html_ file with thefollowing content; it goes in the main _mywebapp_ directory.
 コンパイルを待つ間に、ダミーの HTML ファイルを作成して、ブラウザでサンプル・アプリケーションを簡単に実行できるように、ダミーの HTML ファイルを作成しましょう。以下の内容を mywebapp ディレクトリの index.html に書き込みます。
@@ -434,7 +434,7 @@ ClojureScript コンパイラにはさまざまな最適化レベルがありま
 
 #@# 2. Then, the ClojureScript compiler emits JavaScript code. The result is one   JavaScript output file for each ClojureScript input file.
 //noindent
-2. その後、ClojureScript コンパイラーは ClojureScript の 1 ファイルごとに 1 つのJavaScript の出力ファイルを作成します。
+2. その後、ClojureScript コンパイラは ClojureScript の 1 ファイルごとに 1 つのJavaScript の出力ファイルを作成します。
 
 @<embed>{|latex|\allowbreak }
 
@@ -482,7 +482,7 @@ ClojureScript コンパイラにはさまざまな最適化レベルがありま
 :advanced 最適化は、Google Closure Compiler ルールに従った JavaScript の厳密なサブセットでのみ動作します。ClojureScript はこの厳密なサブセット内に有効な JavaScript を生成しますが、サード・パーティーの JavaScript コードを操作する場合には、全てを期待どおりに動作させるために追加作業が必要になります。
 
 #@# This interaction with third party javascript libraries will be explained in later sections.
-サードパーティの Javascript ライブラリとのやり取りについては、後のセクションで説明します。
+サードパーティの JavaScript ライブラリとのやり取りについては、後のセクションで説明します。
 
 
 #@# Page85
@@ -514,11 +514,11 @@ ClojureScript には、様々な実行環境で REPL を実行するためのサ
 === Nashorn REPL
 
 #@# The Nashorn REPL is the easiest and perhaps most painless REPL environment because itdoes not require any special stuff, just the JVM (JDK 8) that you have used in previous examples for running the ClojureScript compiler.
-Nashorn REPLは、特別なものを必要とせず、ClojureScript コンパイラーを実行するために、以前の例で使用したJVM(JDK8)のみを必要とするため、最も簡単で、おそらく最も苦痛のない REPL 環境です
+Nashorn REPLは、特別なものを必要とせず、ClojureScript コンパイラを実行するために、以前の例で使用したJVM(JDK8)のみを必要とするため、最も簡単で、おそらく最も苦痛のない REPL 環境です
 
 #@# Let’s start creating the repl.clj file with the following content:
 REPL の Playground のために新規でスクリプトファイル repl.clj を作成して、次のように編集します。
- 
+
 //emlist{
 (require '[cljs.repl]
          '[cljs.repl.nashorn])
@@ -723,7 +723,7 @@ cljs.user=> (+ 14 28)
 #@# The Closure Library
 
 #@# The Google Closure Library is a javascript library developed by Google. It has amodular architecture, and provides cross-browser functions for DOM manipulations and events, ajax and JSON, and other features.
-Google Closure Library は Google が開発している Javascript ライブラリです。モジュールのアーキテクチャを備えており、DOM 操作、イベント処理、Ajax 、JSON を扱うためにクロスブラウザの関数を提供します。
+Google Closure Library は Google が開発している JavaScript ライブラリです。モジュールのアーキテクチャを備えており、DOM 操作、イベント処理、Ajax 、JSON を扱うためにクロスブラウザの関数を提供します。
 
 #@# The Google Closure Library is written specifically to take advantage of the ClosureCompiler (which is used internally by the ClojureScript compiler).
 Google Closure Library は、ClojureScript コンパイラで内部的に使用されている Closure Compiler を利用するために書かれています。
@@ -774,12 +774,12 @@ Clojure のプログラムでは、Java クラスをインポートするため�
 #@# For this reason, the remainder of this chapter will explain how to use Leiningen, the de facto clojure build and dependency management tool, for building ClojureScript projects. The boot build tool is also growing in popularity, but for the purposes of this book we will limit ourselves to Leiningen.
 このため、この章の残りの部分では、ClojureScript プロジェクトを構築するために、事実上ビルドと依存関係管理ツールのデファクトである Leiningen の使い方を説明します。boot の人気も高まっていますが、本書では Leiningen に限定します。
 
-=== leiningen のインストール
+=== Leiningen のインストール
 
 #@# Installing leiningen
 
 #@# The installation process of leiningen is quite simple; just follow these steps:
-leiningen のインストール方法は非常に簡単です。次の手順に従ってください。
+Leiningen のインストール方法は非常に簡単です。次の手順に従ってください。
 
 //cmd{
 $ mkdir ~/bin
@@ -801,7 +801,7 @@ Leiningen 2.5.1 on Java 1.8.0_45 OpenJDK 64-Bit Server VM
 //}
 
 #@# We assume here that you are using a Unix-like system such as Linux or BSD. If you are a Windows user, please check the instructions on the Leiningen homepage. You can also get the Linux/Mac OS X/BSD version of the leiningen script at the web site.
-ここでは、Linux や BSD のような Unix ライクなシステムを使っていると仮定しています。Windows ユーザの方は、Leiningen のホームページの説明を参照してください。Linux、Mac OS X、BSD 版の leiningen スクリプトは Web サイトから入手することもできます。
+ここでは、Linux や BSD のような Unix ライクなシステムを使っていると仮定しています。Windows ユーザの方は、Leiningen のホームページの説明を参照してください。Linux、Mac OS X、BSD 版の Leiningen スクリプトは Web サイトから入手することもできます。
 
 
 === 初めてのプロジェクト
@@ -812,10 +812,10 @@ Leiningen 2.5.1 on Java 1.8.0_45 OpenJDK 64-Bit Server VM
 ツールの動作を紹介する最良の方法は、ツールを使用して toy プロジェクトを作成することです。この例では、閏(うるう)年かどうかを判別する小さなアプリケーションを作成します。
 
 #@# To start, we will use the mies leiningen template.
-まず、leiningen の mies テンプレートを使用します。
+まず、Leiningen の mies テンプレートを使用します。
 
 #@# Templates are a facility in leiningen for creating an initial project structure. The clojure community has a great many of them. In this case we’ll use the mies template that was started by the clojurescript core developer. Consult the leiningen docs to learn more about templates.
-テンプレートは、初めのプロジェクト構造を作成するための leiningen の機能です。Clojure コミュニティには非常に多くのものがあります。この例では、Clojurescript の中心的な開発者が作成した mies テンプレートを使用します。テンプレートの詳細については、leiningen のドキュメントを参照してください。
+テンプレートは、初めのプロジェクト構造を作成するための Leiningen の機能です。Clojure コミュニティには非常に多くのものがあります。この例では、ClojureScript の中心的な開発者が作成した mies テンプレートを使用します。テンプレートの詳細については、Leiningen のドキュメントを参照してください。
 
 #@# Let’s start creating the project layout:
 プロジェクトのレイアウトを作成します。
@@ -926,7 +926,7 @@ index.htmlファイルを開き、body の先頭に次の内容を追加しま�
 //}
 
 #@# Now, compile the clojurescript code with:
-次のようにして、Clojurescript コードをコンパイルします。
+次のようにして、ClojureScript コードをコンパイルします。
 
 //cmd{
 $ ./scripts/watch
@@ -946,7 +946,7 @@ rlwrap lein trampoline run -m clojure.main scripts/watch.clj
 最後に、ブラウザで index.html を開きます。テキストボックスに年を入力すると、うるう年の状態が表示されます。
 
 #@# You may have noticed other files in the scripts directory, like build and release. These are the same build scripts mentioned in the previous section, but we will stick with watch here.
-scripts ディレクトリーには、build や release などのファイルがあります。これらは、前のセクションで言及したビルド・スクリプトと同じですが、ここでは watch を使います。
+scripts ディレクトリには、build や release などのファイルがあります。これらは、前のセクションで言及したビルド・スクリプトと同じですが、ここでは watch を使います。
 
 #@# Page94
 #@# @<embed>{|latex|\vspace{-0.5\Cvs\}}
@@ -989,10 +989,10 @@ ClojureScript のコンパイルプロセスに Leiningen を使用する本当�
 ClojureScript に関連するプロパティについて簡単に説明します。
 
 #@# :dependencies: a vector of dependencies that your project needs.
-:dependencies は、プロジェクトに必要な依存関係を含むベクトルです。
+:dependencies は、プロジェクトに必要な依存関係を含むベクタです。
 
 #@# :clean-targets: a vector of paths that lein clean should delete.
-:clean-targets は、lein clean により削除されるパスを含むベクトルです。
+:clean-targets は、lein clean により削除されるパスを含むベクタです。
 
 @<embed>{|latex|\vspace{0.5\Cvs\}}
 
@@ -1009,7 +1009,7 @@ Clojure パッケージは Clojars で公開されることが多いです。ま
 #@# External dependencies
 
 #@# In some circumstances you may found yourself that you need some library but thatdoes not exists in ClojureScript but it is already implemented in javascriptand you want to use it on your project.
-ClojureScript には存在しませんが、すでに Javascript に実装されていて、プロジェクトで使いたいライブラリがある場合があります。
+ClojureScript には存在しませんが、すでに JavaScript に実装されていて、プロジェクトで使いたいライブラリがある場合があります。
 
 #@# There are many ways that you can do it mainly depending on the library that you want to include. Let see some ways.
 含めるライブラリによって、多くの方法があります。いくつか見ていきましょう。
@@ -1029,10 +1029,10 @@ ClojureScript には存在しませんが、すでに Javascript に実装され
 #@# Closure Module compatible library
 
 #@# If you have a library that is just written to be compatible with google closure module system and you want to include it on your project you should just put it in the source (classpath) and access it like any other clojure namespace.
-Google クロージャモジュールとの互換性を持つように作成されたライブラリーをプロジェクトに含める場合には、そのライブラリーをソース(クラスパス)に配置して、他の Clojure 名前空間と同じようにアクセスします。
+Google Closure モジュールとの互換性を持つように作成されたライブラリをプロジェクトに含める場合には、そのライブラリをソース(クラスパス)に配置して、他の Clojure 名前空間と同じようにアクセスします。
 
 #@# This is the most simplest case, because google closure modules are directly compatible and you can mix your clojure code with javascript code written using google closure module system without any additional steps.
-これは最も単純なケースです。Google クロージャモジュールは直接互換性があり、Google クロージャモジュールシステムを使って書かれた Javascript コードは、あなたの Clojure のコードと、追加の手順なしでミックスできます。
+これは最も単純なケースです。Google Closure モジュールは直接互換性があり、Google Closure モジュールシステムを使って書かれた JavaScript コードは、あなたの Clojure のコードと、追加の手順なしでミックスできます。
 
 #@# Let play with it creating new project using mies template:
 mies テンプレートを使用して、新しいプロジェクトを作成してみましょう。
@@ -1043,7 +1043,7 @@ $ cd myextmods
 //}
 
 #@# Create a simple google closure module for experiment:
-実験用に簡単な Google クロージャモジュールを作成します。
+実験用に簡単な Google Closure モジュールを作成します。
 
 @<embed>{|latex|\vspace{0.5\Cvs\}}
 
@@ -1094,7 +1094,7 @@ Node.js  の人気により、Node.js で用いられる CommonJS の人気は�
 \clearpage
 //}
 
-CommonJS のモジュール形式(Google クロージャモジュールを用いた前例と類似点が多い)を使用した単純なファイルを作成します。
+CommonJS のモジュール形式(Google Closure モジュールを用いた前例と類似点が多い)を使用した単純なファイルを作成します。
 
 @<embed>{|latex|\vspace{0.5\Cvs\}}
 
@@ -1167,7 +1167,7 @@ scripts/repl.clj を開いて、次のように変更します。
 グローバルオブジェクトを公開するライブラリを使用するには、CommoJS モジュールと同様の手順を実行する必要がありますが、:module-type 属性を省略する点が異なります。
 
 #@# This will create a synthetic namespace that you should require in order to be able to access to the global object through the js/ namespace. The namespace is called synthetic because it does not expose any object behind it, it just indicates to the compiler that you want that dependency.
-これにより、名前空間の js/ を介してグローバルオブジェクトにアクセスするために必要な名前空間の合成が作成されます。名前空間は、その背後にあるオブジェクトを公開せず、その依存関係が必要であることをコンパイラーに示すだけなので、synthetic と呼ばれます。
+これにより、名前空間の js/ を介してグローバルオブジェクトにアクセスするために必要な名前空間の合成が作成されます。名前空間は、その背後にあるオブジェクトを公開せず、その依存関係が必要であることをコンパイラに示すだけなので、synthetic と呼ばれます。
 
 #@# Let’s play with that. Start creating a simple file declaring just a global function:
 グローバル関数のみを宣言する単純なファイルを作成します。
@@ -1244,10 +1244,10 @@ ClojureScriptのデータ構造はイミュータブルであるため、プロ�
 #@# First steps
 
 #@# The "official" ClojureScript testing framework is in the "cljs.test" namespace. It is a very simple library, but it should be more than enough for our purposes.
-公式の ClojureScript のテスト・フレームワークは、名前空間 cljs.test にあります。これは非常に単純なライブラリーですが、私たちの目的には十分すぎるはずです。
+公式の ClojureScript のテスト・フレームワークは、名前空間 cljs.test にあります。これは非常に単純なライブラリですが、私たちの目的には十分すぎるはずです。
 
 #@# There are other libraries that offer additional features or directly different approaches to testing, such as test.check. However, we will not cover them here.
-他にも、追加の機能を提供したり、テストに対して直接的に異なるアプローチを提供するライブラリーがあります (例えば test.check など)。ただし、ここでは説明しません。
+他にも、追加の機能を提供したり、テストに対して直接的に異なるアプローチを提供するライブラリがあります (例えば test.check など)。ただし、ここでは説明しません。
 
 #@# Start creating a new project using the mies leiningen template for experimenting with tests:
 テストを試すために mies テンプレートを使用して、新しいプロジェクトを作成します。

--- a/5language-advanced.re
+++ b/5language-advanced.re
@@ -169,7 +169,7 @@ map filter mapcat を行うプロセスは、必ずしも具体的な型に結�
 
 
 #@# We've made the previous versions more general since using  reduce  makes our functions work on any thing that is reducible, not just sequences. However you may have noticed that, even though  my-mapr  and  my-filterr  don't know anything about the source ( coll ) they are still tied to the output they produce (a vector) both with the initial value of the reduce ( [] ) and the hardcoded  conj  operation in the body of the reducing function. We could have accumulated results in another data structure, for example a lazy sequence, but we'd have to rewrite the functions in order to do so.
-シーケンスだけでなく reduce を実行できる全てのものに対して関数が機能するようになったため、以前のバージョンをより一般的にすることができました。ただし、my-mapr と my-filterr は、ソース(coll)について何も知りませんが、reduce の初期値([])と reducing 関数の本体内でハードコーディングされた conj と一緒に自ら生成する出力(ベクトル)に結び付けられます。遅延シーケンス等の別のデータ構造に結果を蓄積することもできますが、そのためには関数を書き直さなければなりません。
+シーケンスだけでなく reduce を実行できる全てのものに対して関数が機能するようになったため、以前のバージョンをより一般的にすることができました。ただし、my-mapr と my-filterr は、ソース(coll)について何も知りませんが、reduce の初期値([])と reducing 関数の本体内でハードコーディングされた conj と一緒に自ら生成する出力(ベクタ)に結び付けられます。遅延シーケンス等の別のデータ構造に結果を蓄積することもできますが、そのためには関数を書き直さなければなりません。
 
 #@# How can we make these functions truly generic? They shouldn't know about either the source of inputs they are transforming nor the output that is generated. Have you noticed that  conj  is just another reducing function? It takes an accumulator and an input and returns another accumulator. So, if we parameterise the reducing function that  my-mapr  and  my-filterr  use, they won't know anything about the type of the result they are building. Let's give it a shot:
 これらの関数を本当の意味で汎用的にするにはどうすればよいのでしょうか。これらの関数は、変換中の入力のソースや、生成された出力について知るべきではありません。conj は reducing 関数の1つであることにお気づきでしょうか。アキュムレータと入力を受け取り、別のアキュムレータを返します。したがって、my-mapr my-filterr が使用する reducing 関数をパラメータ化しても、ビルドする結果の型については何も知りません。試してみましょう。
@@ -297,7 +297,7 @@ transducer についての知識が増えたので、独自のバージョンの
 
 
 #@# The  my-cat  transducer returns a reducing function that catenates its inputs into the accumulator. It does so reducing the  input  reducible with the  rfn  reducing function and using the accumulator ( acc ) as the initial value for such reduction.  mapcat  is simply the composition of  map  and  cat . The order in which transducers are composed may seem backwards but it'll become clear in a moment.
-my-cat transducer は、その入力をアキュミュレータに結合する reducing 関数を返します。このようにして、rfn 関数で reduce 可能な入力を reduce して、このような reduce のための初期値としてアキュムレータ(acc)を使用します。mapcat は map と cat の合成です。transducer が構成される順序は逆向きに見えるかもしれませんが、この点については後に明らかにします。
+my-cat transducer は、その入力をアキュムレータに結合する reducing 関数を返します。このようにして、rfn 関数で reduce 可能な入力を reduce して、このような reduce のための初期値としてアキュムレータ(acc)を使用します。mapcat は map と cat の合成です。transducer が構成される順序は逆向きに見えるかもしれませんが、この点については後に明らかにします。
 
 //emlist{
 (defn my-mapcat
@@ -392,7 +392,7 @@ transducer から返される reducing 関数を用いて reduce を使用する
 //}
 
 #@# The  conj  function has a arity 0 version that returns an empty vector but is not the only reducing function that supports arity 0. Let's explore some others:
-conj 関数には空のベクトルを返す引数が必要ないバージョンがありますが、これだけが引数なしを許す reducing 関数という訳ではありません。他の関数も見てみましょう。
+conj 関数には空のベクタを返す引数が必要ないバージョンがありますが、これだけが引数なしを許す reducing 関数という訳ではありません。他の関数も見てみましょう。
 
 
 #@# Page110
@@ -584,7 +584,7 @@ my-take の本体は明らかになっているはずです。次の剰余(nr)�
 @<embed>{|latex|\vspace{-0.3\Cvs\}}
 
 #@# We've seen an example of a stateful transducer but it didn't do anything in its completion step. Let's see an example of a transducer that uses the completion step to flush an accumulated value. We'll implement a simplified version of  partition-all , which given a  n  number of elements converts the inputs in vectors of size  n . For understanding its purpose better let's see what the arity 2 version gives us when providing a number and a collection:
-ステートフルな transducer の例を見てきましたが、完了の段階では何もしませんでした。累積値を表示するために完了のステップを使用する transducer の例を見てみましょう。要素の数が n の要素あれば、サイズが n 個のベクトルの入力を変換する partition-all の簡素版を実装しましょう。目的をよく理解するために、引数を 2 つとる場合で、数字とコレクションを与えると何が得られるかを見てみましょう。
+ステートフルな transducer の例を見てきましたが、完了の段階では何もしませんでした。累積値を表示するために完了のステップを使用する transducer の例を見てみましょう。要素の数が n の要素あれば、サイズが n 個のベクタの入力を変換する partition-all の簡素版を実装しましょう。目的をよく理解するために、引数を 2 つとる場合で、数字とコレクションを与えると何が得られるかを見てみましょう。
 
 @<embed>{|latex|\vspace{-0.3\Cvs\}}
 
@@ -596,7 +596,7 @@ my-take の本体は明らかになっているはずです。次の剰余(nr)�
 @<embed>{|latex|\vspace{-0.3\Cvs\}}
 
 #@# The transducer returning function of  partition-all  will take a number  n  and return a transducer that groups inputs in vectors of size  n . In the completion step it will check if there is an accumulated result and, if so, add it to the result. Here's a simplified version of ClojureScript core  partition-all  function, where  array-list  is a wrapper for a mutable JavaScript array:
-partition-all の transducer を返す関数は、数値 n を取り、n 個のサイズのベクトルで入力をグループ化する transducer を返しまる。完了する段階では、累積結果があるかどうかを確認して、ある場合は結果に追加します。以下は、ClojureScript のコア関数である partition-all を単純化したもので、array-list は変更可能な JavaScript の配列のラッパーです。
+partition-all の transducer を返す関数は、数値 n を取り、n 個のサイズのベクタで入力をグループ化する transducer を返しまる。完了する段階では、累積結果があるかどうかを確認して、ある場合は結果に追加します。以下は、ClojureScript のコア関数である partition-all を単純化したもので、array-list は変更可能な JavaScript の配列のラッパーです。
 
 @<embed>{|latex|\vspace{-0.3\Cvs\}}
 
@@ -974,10 +974,10 @@ ClojureScriptの不変で永続的なデータ構造は、それなりのパフ�
 //}
 
 #@# In the above example we are generating a vector of 100 elements  conj -ing one at a time. Every intermediate vector that is not the final result won't be seen by anybody except the  into  function and the array copying required for persistence is an unnecesary overhead.
-上の例では、100 個の要素からなるベクトルを一度に一つずつ conj しながら生成しています。最終的な結果でない全ての中間ベクトルは into 関数以外では見ることができず、永続化のために必要な配列のコピーは不要なオーバーヘッドです。
+上の例では、100 個の要素からなるベクタを一度に一つずつ conj しながら生成しています。最終的な結果でない全ての中間ベクタは into 関数以外では見ることができず、永続化のために必要な配列のコピーは不要なオーバーヘッドです。
 
 #@# For these situations ClojureScript provides a special version of some of its persistent data structures, which are called transients. Maps, vectors and sets have a transient counterpart.  Transients are always derived from a persistent data structure using the  transient  function, which creates a transient version in constant time:
-このような状況のために、ClojureScript は transient と呼ばれる永続的なデータ構造を提供しています。マップ、ベクトル、セットには、transient に相当するものがあります。Transient は、常に transient 関数を使用して、永続的なデータ構造から生成されます。これにより、一定の時間内に、transient のバージョンが作成されます。
+このような状況のために、ClojureScript は transient と呼ばれる永続的なデータ構造を提供しています。マップ、ベクタ、セットには、transient に相当するものがあります。Transient は、常に transient 関数を使用して、永続的なデータ構造から生成されます。これにより、一定の時間内に、transient のバージョンが作成されます。
 
 @<embed>{|latex|\vspace{-0.4\Cvs\}}
 
@@ -1045,7 +1045,7 @@ transient には更新のための永続的で不変なセマンティクスが�
 //}
 
 #@# As you can see, the transient version of the vector is neither immutable nor persistent. Instead, the vector is mutated in place. Although we could transform  tv  repeatedly using  conj!  on it we shouldn't abandon the idioms used with the persistent data structures: when transforming a transient, use the returned version of it for further modifications like in the following example:
-このように、ベクトルの transient バージョンは不変でも永続でもありません。その代わり、ベクターはその場で変異します。conj! を使って繰り返し tv を変換することもできますが、永続的なデータ構造で使用されるイディオムを放棄してはいけません。transient のデータを変換する場合は、次の例のように、その戻されたバージョンを使用して変更を加えます。
+このように、ベクタの transient バージョンは不変でも永続でもありません。その代わり、ベクタはその場で変異します。conj! を使って繰り返し tv を変換することもできますが、永続的なデータ構造で使用されるイディオムを放棄してはいけません。transient のデータを変換する場合は、次の例のように、その戻されたバージョンを使用して変更を加えます。
 
 //emlist{
 (-> [1 2 3]
@@ -1271,7 +1271,7 @@ ClojureScript の等価性は値に基づいているため、メタデータが
 //}
 
 #@# As you can see in the example above, metadata is preserved in derived versions of persistent data structures. There are some subtleties, though. As long as the functions that derive new data structures return collections with the same type, metadata will be preserved; this is not true if the types change due to the transformation. To ilustrate this point, let's see what happens when we derive a seq or a subvector from a vector:
-この例でわかるように、メタデータは永続的なデータ構造の派生バージョンで保持されます。微妙なところもありますが、新しいデータ構造を派生する関数が同じ型のコレクションを返す限り、メタデータは保存されます。これは、変換によって型が変更される場合には当てはまりません。この点を理解するために、ベクトルから seq や subvector を派生させると何が起こるかを見てみましょう。
+この例でわかるように、メタデータは永続的なデータ構造の派生バージョンで保持されます。微妙なところもありますが、新しいデータ構造を派生する関数が同じ型のコレクションを返す限り、メタデータは保存されます。これは、変換によって型が変更される場合には当てはまりません。この点を理解するために、ベクタから seq や subvector を派生させると何が起こるかを見てみましょう。
 
 
 #@# Page125
@@ -1461,7 +1461,7 @@ ClojureScript の core に定義されている関数群がプロトコルを中
 #@# Functions
 
 #@# As we've learned in previous chapters not only functions can be invoked. Vectors are functions of their indexes, maps are functions of their keys and sets are functions of their values.
-これまでの章で学んだように、関数だけが呼び出されるものとは限りません。ベクトルはインデックス、マップはキー、セットは値を関数のように使うことができます。
+これまでの章で学んだように、関数だけが呼び出されるものとは限りません。ベクタはインデックス、マップはキー、セットは値を関数のように使うことができます。
 
 #@# We can extend types to be callable as functions implementing the  IFn  protocol. A collection that doesn't support calling it as a function is the queue, let's implement  IFn  for the  PersistentQueue  type so we're able to call queues as functions of their indexes:
 IFn プロトコルを実装する関数として呼び出し可能な型に拡張することができます。関数としての呼び出しをサポートしていないコレクションが queue です。PersistentQueue 型に IFn を実装して、queue をインデックスの関数として呼び出すことができるようにします。
@@ -1532,7 +1532,7 @@ IFn プロトコルを実装する関数として呼び出し可能な型に拡�
 
 @<embed>{|latex|\vspace{-0.3\Cvs\}}
 
-=== シークエンス
+=== シーケンス
 
 #@# Sequences
 
@@ -1712,7 +1712,7 @@ count 関数を使用して一定の時間でカウントできるコレクシ�
 //}
 
 #@# Some collection types such as vectors and lists can be indexed by a number using the  nth  function. If our types are indexed we can implement the  IIndexed  protocol:
-ベクトルやリストなどのコレクション型は、nth 関数でインデックス番号を付けることができます。もし私たちの型がインデックスされるなら、私たちは IIndexed プロトコルを実装することができます:
+ベクタやリストなどのコレクション型は、nth 関数でインデックス番号を付けることができます。もし私たちの型がインデックスされるなら、私たちは IIndexed プロトコルを実装することができます:
 
 
 #@# Page132
@@ -2276,10 +2276,10 @@ JavaScript の配列は ClojureScript でも reduce できます。
 //}
 
 #@# Associative data structures can be reduced with the  reduce-kv  function, which is based in the  IKVReduce  protocol. The main difference between  reduce  and  reduce-kv  is that the latter uses a three-argument function as a reducer, receiving the accumulator, key and value for each item.
-連想的なデータ構造は IKVReduce プロトコルに基づく reduce‐kv 関数を用いて reduce できます。reduce と reduce-kv の主な違いは、reduce-kv は 3 つの引数をとる関数であり、reducer、アキュミュレータの受け取り、各アイテムのキーと値をとることです。
+連想的なデータ構造は IKVReduce プロトコルに基づく reduce‐kv 関数を用いて reduce できます。reduce と reduce-kv の主な違いは、reduce-kv は 3 つの引数をとる関数であり、reducer、アキュムレータの受け取り、各アイテムのキーと値をとることです。
 
 #@# Let's look at an example, we will reduce a map to a vector of pairs. Note that, since vectors associate indexes to values, they can also be reduced with  reduce-kv .
-例を見てみましょう。マップをペアからなるベクトルに変換します。ベクトルはインデックスを値に関連付けるので、reduce-kv を使って値を reduce することができます。
+例を見てみましょう。マップをペアからなるベクタに変換します。ベクタはインデックスを値に関連付けるので、reduce-kv を使って値を reduce することができます。
 
 //emlist{
 (reduce-kv (fn [acc k v]
@@ -2291,7 +2291,7 @@ JavaScript の配列は ClojureScript でも reduce できます。
 //}
 
 #@# We'll extend the new ES6 map type to support  reduce-kv , we'll do this by getting a sequence of key-value pairs and calling the reducing function with the accumulator, key and value as positional arguments:
-新しい ES6 のマップ型を拡張して、reduce-kv をサポートするようにします。これを行うには、キーと値のペアのシーケンスを取得し、アキュミュレータ、キー、値を位置を示す引数として使用して reducing 関数を呼び出します。
+新しい ES6 のマップ型を拡張して、reduce-kv をサポートするようにします。これを行うには、キーと値のペアのシーケンスを取得し、アキュムレータ、キー、値を位置を示す引数として使用して reducing 関数を呼び出します。
 
 
 #@# Page141
@@ -3384,13 +3384,13 @@ timeout 関数と ats! を組み合わせることで、簡単にチャンネル
 
 
 #@# In the example above we launched a go block that, after waiting for a second, puts a value in the  ch  channel. The other go block creates a  cancel  channel, which will be closed after 300 miliseconds. After that, it tries to read from both  ch  and  cancel  at the same time using  alts! , which will succeed whenever it can take a value from either of those channels. Since  cancel  is closed after 300 miliseconds,  alts!  will succeed since takes from closed channel return the  nil  sentinel. Note that  alts!  returns a two-element vector with the returned value of the operation and the channel where it was performed.
-上の例では、1 秒待ってから ch チャンネルに値を入れる go ブロックを起動しました。もう一方の go ブロックは、300 ミリ秒後に閉じる cancel チャンネルを作成します。その後、alts! を使って ch からの読み込みとキャンセルを同時に行おうとします。これらいずれかのチャンネルから値を取得できる場合は、常に成功します。cancel は 300 ミリ秒後にクローズされて、閉じたチャンネルからの take が　nil sentinel を返すため、alts! は成功します。alts! が 2 つの要素からなるベクトルを返することに注目してください。それらは、操作による返り値と、実行されたチャンネルを含みます。
+上の例では、1 秒待ってから ch チャンネルに値を入れる go ブロックを起動しました。もう一方の go ブロックは、300 ミリ秒後に閉じる cancel チャンネルを作成します。その後、alts! を使って ch からの読み込みとキャンセルを同時に行おうとします。これらいずれかのチャンネルから値を取得できる場合は、常に成功します。cancel は 300 ミリ秒後にクローズされて、閉じたチャンネルからの take が　nil sentinel を返すため、alts! は成功します。alts! が 2 つの要素からなるベクタを返することに注目してください。それらは、操作による返り値と、実行されたチャンネルを含みます。
 
 #@# This is why we are able to detect whether the read operation was performed in the  cancel  channel or in  ch . I suggest you copy this example and set the first process timeout to 100 miliseconds to see how the read operation on  ch  succeeds.
 このため、candel チャンネルで read の操作が行われたか、ch チャンネルで行われたかを検出することができます。この例をコピーして、最初のプロセスの timeout を 100 ミリ秒に設定して、ch チャンネルに対する read の操作がどのように成功するかを確認することをお勧めします。
 
 #@# We've learned how to choose between read operations so let's look at how to express a conditional write operation in  alts! . Since we need to provide the channel and a value to try to put on it, we'll use a two element vector with the channel and the value for representing write operations.
-read の操作間での選択方法を学んだので、alt! で条件付きの read の操作を表現する方法を見てみましょう。チャンネルとその上に置こうとする値を提供する必要があるため、チャンネルと write の操作を表す値を持つ 2 つの要素のベクトルを使用します。
+read の操作間での選択方法を学んだので、alt! で条件付きの read の操作を表現する方法を見てみましょう。チャンネルとその上に置こうとする値を提供する必要があるため、チャンネルと write の操作を表す値を持つ 2 つの要素のベクタを使用します。
 
 #@# Let's see an example:
 
@@ -3703,7 +3703,7 @@ pipeline-async は ある数字を受け取りますが、その数字は、並�
 ===== split
 
 #@# split  takes a predicate and a channel and returns a vector with two channels, the first of which will receive the values for which the predicate is true, the second will receive those for which the predicate is false. We can optionally pass a buffer or number for the channels with the third (true channel) and fourth (false channel) arguments.
-split は述部とチャンネルを取り、2 つのチャンネルを持つベクトルを返します。最初のチャンネルは述部が true の値を受け取り、2 番目のチャンネルは述部が false の値を受け取ります。オプションで 3 番目(true チャンネル)と4番目(false チャンネル)の引数を使って、チャンネルのバッファまたは数字を渡すことができます。
+split は述部とチャンネルを取り、2 つのチャンネルを持つベクタを返します。最初のチャンネルは述部が true の値を受け取り、2 番目のチャンネルは述部が false の値を受け取ります。オプションで 3 番目(true チャンネル)と4番目(false チャンネル)の引数を使って、チャンネルのバッファまたは数字を渡すことができます。
 
 //emlist{
 (require '[cljs.core.async :refer [chan split put! <! close!]])


### PR DESCRIPTION
めぼしい表記揺れを修正しました：

| 修正前 | 修正後 |
|-------|--------|
| Clojurescript | ClojureScript |
| Javascript | JavaScript |
| leiningen | Leiningen |
| Google クロージャ | Google Closure |
| コンパイラー | コンパイラ |
| ライブラリー | ライブラリ |
| ディレクトリー | ディレクトリ |
| シークエンス | シーケンス |
| ベクター、ベクトル | ベクタ |
| 不可変 | 不変 |
| アキュミュレータ | アキュムレータ |
| サードバーティー | サードパーティ |

「不変」と「イミュータブル」、「可変」と「ミュータブル」もそれぞれ同義語だと思いますが、ここでは一旦保留にしています。